### PR TITLE
Graceful Server Shutdown with K8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.0
+FROM node:14.15.4
 
 # Enable apt-get to run from the new sources.
 RUN printf "deb http://archive.debian.org/debian/ \
@@ -10,6 +10,9 @@ RUN printf "deb http://archive.debian.org/debian/ \
 # Update everything on the box
 RUN apt-get -y update
 RUN apt-get clean
+
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.4/dumb-init_1.2.4_amd64.deb
+RUN dpkg -i dumb-init_*.deb
 
 # Set the working directory
 WORKDIR /srv/src
@@ -28,4 +31,5 @@ COPY . /srv/src
 RUN cd /srv/src && wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem
 
 # Start the app
-CMD npm run start
+ENV NODE_ENV=production
+CMD ["dumb-init", "node", "src/index.js"]

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "docusaurus": "^1.14.6",
     "express": "^4.17.1",
     "fast-json-patch": "^2.0.7",
+    "http-terminator": "^2.0.3",
     "joi": "^17.3.0",
     "moment-timezone": "^0.5.14",
     "mongodb": "^3.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-const { app, fhirApp } = require('./app');
+const { createHttpTerminator } = require('http-terminator');
 
+const { app, fhirApp } = require('./app');
 const asyncHandler = require('./lib/async-handler');
 const mongoClient = require('./lib/mongo');
 const globals = require('./globals');
@@ -21,9 +22,26 @@ const main = async function () {
   globals.set(CLIENT, client);
   globals.set(CLIENT_DB, client.db(mongoConfig.db_name));
 
-  app.listen(fhirServerConfig.server.port, () =>
+  const server = app.listen(fhirServerConfig.server.port, () =>
     fhirApp.logger.verbose('Server is up and running!')
   );
+
+  const httpTerminator = createHttpTerminator({
+    server,
+    gracefulTerminationTimeout: 7000,
+  });
+
+  process.on('SIGTERM', async function onSigterm() {
+    fhirApp.logger.info('Beginning shutdown of server');
+    try {
+      await httpTerminator.terminate();
+      fhirApp.logger.info('Successfully shut down server');
+      process.exit(0);
+    } catch (error) {
+      fhirApp.logger.error('Failed to shutdown server: ', error);
+      process.exit(1);
+    }
+  });
 };
 
 main();


### PR DESCRIPTION
* Dockerfile switch to node from npm.  NPM swallows process signals
* added http-terminator to handle network connections during shutdown